### PR TITLE
adding performance optimisation: reusing comparision function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,14 @@ export default function (resultFn: Function, isEqual?: EqualityFn = simpleIsEqua
     let lastResult: any;
     let calledOnce: boolean = false;
 
-    // breaking cache when arguments or context changes
+    const isNewArgEqualToLast = (newArg, index) => isEqual(newArg, lastArgs[index]);
+
+    // breaking cache when context (this) or arguments change
     return function (...newArgs: Array<any>) {
         if (calledOnce &&
             lastThis === this &&
             newArgs.length === lastArgs.length &&
-            lastArgs.every((lastArg, i) => isEqual(lastArg, newArgs[i]))) {
+            newArgs.every(isNewArgEqualToLast)) {
             return lastResult;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -441,7 +441,7 @@ describe('memoizeOne', () => {
             memoizedAdd(1, 4);
 
             expect(equalityStub.calledWith(1, 1)).to.be.true;
-            expect(equalityStub.calledWith(2, 4)).to.be.true;
+            expect(equalityStub.calledWith(4, 2)).to.be.true;
         });
 
         it('should return the previous value without executing the result fn if the equality fn returns true', () => {


### PR DESCRIPTION
Technically this is slightly different behaviour for the comparison function. Previously `isEqual` was called like:

`isEqual(oldArg, newArg)`. 

However, this optimised version now calls it in the reverse order:

`isEqual(newArg, oldArg)`. 

The reversal was required in order to pull the `.every` function up so it could be reused. 

While the order of arguments to the `isEqual` function is different - I do not think it is a "breaking change". The equality function was never advertised a particular order of params. The idea of it is to allow custom equality functions such as `deepEqual` functions to compare to values. However, some people may have been relying on the specific order of the params in their functions. I could be convinced to do a major version bump if people think that is appropriate. However, given the low usage of this library at this stage I suspect that this use case does not exist at present. 

As part of this PR I have updated the `type` of the `EqualityFn` type to clearly call out the order of the params so that it is clearer.

```js
type EqualityFn = (newArg: any, lastArg: any) => boolean
```