### PR TITLE
removing module export from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.2",
   "description": "A memoization library which only remembers the latest invocation",
   "main": "lib/index.js",
-  "module": "src/index.js",
   "author": "Alex Reardon <alexreardon@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Currently the `module` export in `package.json` includes flow code. This is probably not expected. Given that `memoize-one` has no dependencies there seems to be little utility at this stage in having a `module` export. 