### PR TITLE
Respect function argument count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,13 @@ type EqualityFn = (a: mixed, b: mixed) => boolean;
 
 const simpleIsEqual: EqualityFn = (a: mixed, b: mixed): boolean => a === b;
 
+const defineProperty = (target: Object, property: string, value: mixed) =>
+  Object.defineProperty(target, property, {
+    writable: false,
+    configurable: true,
+    value: value,
+  });
+
 // <ResultFn: (...Array<any>) => mixed>
 // The purpose of this typing is to ensure that the returned memoized
 // function has the same type as the provided function (`resultFn`).
@@ -33,11 +40,9 @@ export default function <ResultFn: (...Array<any>) => mixed>(resultFn: ResultFn,
     return lastResult;
   };
 
-  Object.defineProperty(result, 'length', {
-    writable: false,
-    configurable: true,
-    value: resultFn.length,
-  });
+  defineProperty(result, 'length', resultFn.length);
+
+  defineProperty(result, 'name', `memoized_${resultFn.name || 'one'}`);
 
   // telling flow to ignore the type of `result` as we know it is `ResultFn`
   return (result: any);

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,12 @@ export default function <ResultFn: (...Array<any>) => mixed>(resultFn: ResultFn,
     return lastResult;
   };
 
+  Object.defineProperty(result, 'length', {
+    writable: false,
+    configurable: true,
+    value: resultFn.length,
+  });
+
   // telling flow to ignore the type of `result` as we know it is `ResultFn`
   return (result: any);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -490,6 +490,15 @@ describe('memoizeOne', () => {
       expect(memoizeOne((...rest) => rest).length).to.equal(0);
       expect(memoizeOne((a, ...rest) => a + rest).length).to.equal(1);
     });
+
+    it('should maintain function name', () => {
+      const fn = a => a;
+      expect(memoizeOne(fn).name).to.equal('memoized_fn');
+      expect(memoizeOne(a => a).name).to.equal('memoized_one');
+      expect(memoizeOne(function test(a) {
+        return a;
+      }).name).to.equal('memoized_test');
+    });
   });
 
   describe('flow typing', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -483,6 +483,15 @@ describe('memoizeOne', () => {
     });
   });
 
+  describe('js typing', () => {
+    it('should maintain function arguments count', () => {
+      expect(memoizeOne(a => a).length).to.equal(1);
+      expect(memoizeOne((a, b) => a + b).length).to.equal(2);
+      expect(memoizeOne((...rest) => rest).length).to.equal(0);
+      expect(memoizeOne((a, ...rest) => a + rest).length).to.equal(1);
+    });
+  });
+
   describe('flow typing', () => {
     it('should maintain the type of the original function', () => {
       // this test will create a flow error if the typing is incorrect


### PR DESCRIPTION
A lot of libraries relay on arguments count - react-redux will deoptimize mapStateToProps if argument count is not 1, fast-memoize changes it's logic(and stops working as long arg count is 0), and so on.

The idea of this PR is simple - just pass down the original function length. As long it is readonly - do it via descriptor.