### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ result3 === result4 // true - arguments are deep equal
 Here is the expected [flow](http://flowtype.org) type signature for a custom equality function:
 
 ```js
-type EqualityFn = (a: any, b: any) => boolean;
+type EqualityFn = (a: mixed, b: mixed) => boolean;
 ```
 
 ## Installation


### PR DESCRIPTION
This is just a really small change to equality function type annotation in the README file.

According to flow docs, `any` is an opt-out of type-checking so I guess you should probably strict things up a bit and use `mixed`
https://flow.org/en/docs/types/any/

Thank you for this little package! 👍