### PR TITLE
Add example for custom equality function with multiple arguments to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ const result2 = memoizedMakeCountObj(
   {b: null, count: 2},
   {b: null, count: 3}
 );
+
+result1 === result2; // true - same reference
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ Here is the expected [flow](http://flowtype.org) type signature for a custom equ
 type EqualityFn = (a: mixed, b: mixed) => boolean;
 ```
 
+#### Custom equality function with multiple arguments
+
+If the function you want to memoize takes multiple arguments, your custom equality function will be called once for each argument and will be passed each argument's new value and last value.
+
+```js
+import memoizeOne from 'memoize-one';
+
+const makeCountObj = (first, second, third) => ({
+  first: first.count,
+  second: second.count,
+  third: third.count,
+});
+
+const areCountPropertiesEqual = (newArg, lastArg) => newArg.count === lastArg.count;
+// runs once for first's new and last values, once for second's, etc.
+
+const memoizedMakeCountObj = memoizeOne(makeCountObj, areCountPropertiesEqual);
+
+const result1 = memoizedMakeCountObj(
+  {a: '?', count: 1},
+  {a: '$', count: 2},
+  {a: '#', count: 3}
+);
+const result2 = memoizedMakeCountObj(
+  {b: null, count: 1},
+  {b: null, count: 2},
+  {b: null, count: 3}
+);
+```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
I'm probably the only one who didn't immediately understand this, but coming right from lodash memoize to this it took me a second to realize that the custom equality function isn't passed all of the arguments at once. It was apparent after looking at the source, but I thought the README could use a word or two about it.

Thank you for this!