### PR TITLE
fix: use named "default" export option for CJS build (BREAKING CHANGE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build:clean": "rimraf dist",
     "build:dist": "rollup -c",
     "build:flow": "echo \"// @flow\n\nexport * from '../src';\" > dist/memoize-one.cjs.js.flow",
-    "prepublish": "yarn run build"
+    "prepublish": "yarn run build",
+    "prepare": "yarn run build"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,6 +53,7 @@ export default [
     output: {
       file: 'dist/memoize-one.cjs.js',
       format: 'cjs',
+      exports: 'named'
     },
     plugins: [babel()],
   },


### PR DESCRIPTION
This PR bring the CJS and ESM modules into alignment, so that `import memoize from 'memoize'` works correctly whether in TypeScript, Jest, or Webpack. It does this by modifying the CJS module to have an export named "default", which is literally how ESM default exports work.

Fixes #37

BREAKING CHANGE: Node users will have to use `var memoize = require('memoize').default` from now on.