### PR TITLE
add index to equality function

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ result3 === result4 // true - arguments are deep equal
 Here is the expected [flow](http://flowtype.org) type signature for a custom equality function:
 
 ```js
-type EqualityFn = (a: mixed, b: mixed) => boolean;
+type EqualityFn = (a: mixed, b: mixed, index: number) => boolean;
 ```
 
 #### Custom equality function with multiple arguments

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-type EqualityFn = (a: mixed, b: mixed) => boolean;
+type EqualityFn = (a: mixed, b: mixed, index: number) => boolean;
 
 const simpleIsEqual: EqualityFn = (a: mixed, b: mixed): boolean => a === b;
 
@@ -15,7 +15,7 @@ export default function <ResultFn: (...Array<any>) => mixed>(resultFn: ResultFn,
   let lastResult: mixed;
   let calledOnce: boolean = false;
 
-  const isNewArgEqualToLast = (newArg: mixed, index: number): boolean => isEqual(newArg, lastArgs[index]);
+  const isNewArgEqualToLast = (newArg: mixed, index: number): boolean => isEqual(newArg, lastArgs[index], index);
 
   // breaking cache when context (this) or arguments change
   const result = function (...newArgs: Array<mixed>) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -436,8 +436,8 @@ describe('memoizeOne', () => {
       // will trigger equality check
       memoizedAdd(1, 4);
 
-      expect(equalityStub).toHaveBeenCalledWith(1, 1);
-      expect(equalityStub).toHaveBeenCalledWith(4, 2);
+      expect(equalityStub).toHaveBeenCalledWith(1, 1, 0);
+      expect(equalityStub).toHaveBeenCalledWith(4, 2, 1);
     });
 
     it('should return the previous value without executing the result fn if the equality fn returns true', () => {


### PR DESCRIPTION
it's common that we have args in different forms, without the index it's hard to compare according to the arg's form