### PR TITLE
no more index argument

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,4 +2,4 @@
 
 # Provides a way to suppress flow errors in the following line.
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment= \\(.\\|\n\\)*\\$ExpectEror
+suppress_comment= \\(.\\|\n\\)*\\$ExpectError

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you are in a CommonJS environment (eg [Node](https://nodejs.org)), then **you
 const memoizeOne = require('memoize-one').default;
 ```
 
-### Custom equality function
+## Custom equality function
 
 The default equality function is a simple shallow equal check
 
@@ -110,7 +110,7 @@ const result4 = customMemoization({foo: 'bar'});
 result3 === result4 // true - arguments are deep equal
 ```
 
-#### Custom equality function behaviour
+### Custom equality function behaviour
 
 - The equality function is only called if the `this` context of the function has not changed, and the `length` of the arguments has not changed.
 - The equality function is used to compare the value of every individual argument by index.
@@ -125,7 +125,7 @@ equality function calls:
 first call: `isEqual(0, 0)`
 second call: `isEqual(1, 2)`
 
-#### Custom equality function higher order functions
+### Custom equality function higher order functions
 
 > This is super advanced behaviour. Generally you will not need to do this!
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ A memoization library that only caches the result of the most recent arguments.
 
 ## Rationale
 
-Cache invalidation is hard:
-
-> There are only two hard things in Computer Science: cache invalidation and naming things.
->
-> *Phil Karlton*
-
-So keep things simple and just use a cache size of one!
-
 Unlike other memoization libraries, `memoize-one` only remembers the latest arguments and result. No need to worry about cache busting mechanisms such as `maxAge`, `maxSize`, `exclusions` and so on which can be prone to memory leaks. `memoize-one` simply remembers the last arguments, and if the function is next called with the same arguments then it returns the previous result.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ console.log(value1 === value3);
 - [simple arguments](https://www.measurethat.net/Benchmarks/ShowResult/4452)
 - [complex arguments](https://www.measurethat.net/Benchmarks/ShowResult/4488)
 
-The comparisions are not exhaustive and are primiarly to show that `memoize-one` accomplishes remembering the latest invocation really fast. The benchmarks do not take into account the differences in feature sets, library sizes, parse time, and so on.
+The comparisons are not exhaustive and are primarily to show that `memoize-one` accomplishes remembering the latest invocation really fast. The benchmarks do not take into account the differences in feature sets, library sizes, parse time, and so on.
 
 ## Code health :thumbsup:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ second call: `isEqual(1, 2)`
 
 ### Custom equality function higher order functions
 
-> This is super advanced behaviour. Generally you will not need to do this!
+> ⚠️ Generally you will not need to do this. There are some rare use cases where additional information in your custom equality function can be useful. We have optimised the custom equality function api for common use cases. There is some additional work you will need to do to unlock more advanced behaviours.
 
 We do not provide extra details to custom equality functions such as argument `index` for [compatibility reasons](https://github.com/alexreardon/memoize-one/issues/47). However, you can add extra information yourself to your custom equality functions with a higher order function (wrapping a function in another function).
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ second call: `isEqual(1, 2)`
 
 > This is super advanced behaviour. Generally you will not need to do this!
 
-We do not provide extra details to custom equality functions such as argument `index` for [compatibility reasons](TODO). However, you can add extra information yourself to your custom equality functions with a higher order function (wrapping a function in another function).
+We do not provide extra details to custom equality functions such as argument `index` for [compatibility reasons](https://github.com/alexreardon/memoize-one/issues/47). However, you can add extra information yourself to your custom equality functions with a higher order function (wrapping a function in another function).
 
 #### Example: `index`
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
-type EqualityFn = (newValue: mixed, oldValue: mixed, index: number) => boolean;
+type EqualityFn = (newValue: mixed, oldValue: mixed) => boolean;
 
-const simpleIsEqual: EqualityFn = (a: mixed, b: mixed): boolean => a === b;
+const simpleIsEqual: EqualityFn = (newValue: mixed, oldValue: mixed): boolean => newValue === oldValue;
 
 // <ResultFn: (...Array<any>) => mixed>
 // The purpose of this typing is to ensure that the returned memoized
@@ -15,7 +15,7 @@ export default function <ResultFn: (...Array<any>) => mixed>(resultFn: ResultFn,
   let lastResult: mixed;
   let calledOnce: boolean = false;
 
-  const isNewArgEqualToLast = (newArg: mixed, index: number): boolean => isEqual(newArg, lastArgs[index], index);
+  const isNewArgEqualToLast = (newArg: mixed, index: number): boolean => isEqual(newArg, lastArgs[index]);
 
   // breaking cache when context (this) or arguments change
   const result = function (...newArgs: Array<mixed>) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -417,6 +417,44 @@ describe('memoizeOne', () => {
     });
   });
 
+  describe('skip equality check', () => {
+    it('should not run any equality checks if the arguments length changes', () => {
+      const mock = jest.fn();
+      const isEqual = jest.fn().mockReturnValue(true);
+      const memoized = memoizeOne(mock);
+
+      memoized(1, 2);
+      // not executed on original call
+      expect(isEqual).not.toHaveBeenCalled();
+
+      // not executed as argument length has changed
+      memoized(1, 2, 3);
+      expect(isEqual).not.toHaveBeenCalled();
+    });
+
+    it('should not run any equality checks if the "this" context changes', () => {
+      const isEqual = jest.fn().mockReturnValue(true);
+      const memoized = memoizeOne(getA);
+      const obj1 = {
+        a: 10,
+      };
+      const obj2 = {
+        a: 20,
+      };
+      const args: number[] = [1, 2, 3];
+
+      // using explicit binding change
+
+      // custom equality function not called on first call
+      expect(memoized.apply(obj1, args)).toBe(10);
+      expect(isEqual).not.toHaveBeenCalled();
+
+      // not executed as "this" context has changed
+      expect(memoized.apply(obj2, args)).toBe(20);
+      expect(isEqual).not.toHaveBeenCalled();
+    });
+  });
+
   describe('custom equality function', () => {
     let add;
     let memoizedAdd;
@@ -436,8 +474,8 @@ describe('memoizeOne', () => {
       // will trigger equality check
       memoizedAdd(1, 4);
 
-      expect(equalityStub).toHaveBeenCalledWith(1, 1, 0);
-      expect(equalityStub).toHaveBeenCalledWith(4, 2, 1);
+      expect(equalityStub).toHaveBeenCalledWith(1, 1);
+      expect(equalityStub).toHaveBeenCalledWith(4, 2);
     });
 
     it('should return the previous value without executing the result fn if the equality fn returns true', () => {
@@ -483,7 +521,6 @@ describe('memoizeOne', () => {
   });
 
   describe('throwing', () => {
-
     it('should throw when the memoized function throws', () => {
       const willThrow = (message: string) => {
         throw new Error(message);
@@ -613,6 +650,87 @@ describe('memoizeOne', () => {
     });
   });
 
+  describe('custom equality function higher order functions', () => {
+    it('should support a higher order function with index', () => {
+      const mock = jest.fn();
+
+      function isDate(value: mixed): boolean %checks {
+        return value instanceof Date;
+      }
+
+      // this function will do some special checking for the second argument
+      const customIsEqual = (newValue: mixed, oldValue: mixed, index: number): boolean => {
+        if (index !== 1) {
+          return newValue === oldValue;
+        }
+        if (!isDate(newValue) || !isDate(oldValue)) {
+          return false;
+        }
+        return newValue.getTime() === oldValue.getTime();
+
+      };
+
+      const getMemoizedWithIndex = (fn: Function) => {
+        let argIndex: number = 0;
+        const withIndex = (newValue: mixed, oldValue: mixed) => customIsEqual(newValue, oldValue, argIndex++);
+        return memoizeOne(fn, withIndex);
+      };
+
+      const memoized = getMemoizedWithIndex(mock);
+
+      memoized(1, new Date(2019, 1));
+      memoized(1, new Date(2019, 1));
+
+      expect(mock).toHaveBeenCalledTimes(1);
+      expect(mock).toHaveBeenCalledWith(1, new Date(2019, 1));
+
+      // new date value - breaks memoization
+      mock.mockClear();
+      memoized(1, new Date(2019, 2));
+      expect(mock).toHaveBeenCalledTimes(1);
+      expect(mock).toHaveBeenCalledWith(1, new Date(2019, 2));
+    });
+
+    it('should support a higher order function with index and args', () => {
+      const mock = jest.fn();
+
+      // using this to only memoize calls with 3+ arguments
+      const customIsEqual = (newValue: mixed, oldValue: mixed, index: number, args: mixed[]): boolean => {
+        if (args.length < 3) {
+          return false;
+        }
+        return newValue === oldValue;
+      };
+      const getMemoizedFn = (fn: Function) => {
+        let args: mixed[] = [];
+        let argIndex: number = 0;
+        const withIndex = (newValue: mixed, oldValue: mixed) => customIsEqual(newValue, oldValue, argIndex++, args);
+        const memoized = memoizeOne(fn, withIndex);
+
+        return (...newArgs: mixed[]) => {
+          args = newArgs;
+          return memoized(...newArgs);
+        };
+      };
+
+      const memoized = getMemoizedFn(mock);
+
+      memoized(1, 2, 3);
+      memoized(1, 2, 3);
+
+      expect(mock).toHaveBeenCalledTimes(1);
+      expect(mock).toHaveBeenCalledWith(1, 2, 3);
+
+      mock.mockClear();
+
+      memoized(1, 2);
+      memoized(1, 2);
+
+      expect(mock).toHaveBeenCalledTimes(2);
+      expect(mock).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
   describe('flow typing', () => {
     it('should maintain the type of the original function', () => {
       // this test will create a flow error if the typing is incorrect
@@ -628,21 +746,6 @@ describe('memoizeOne', () => {
 
       expect(result1).toBe(1);
       expect(result2).toBe(1);
-    });
-
-    it('should allow a custom equality fn with an index argument', () => {
-      const fn = (...args: mixed[]) => {
-        // eslint-disable-next-line no-console
-        console.log(...args);
-      };
-
-      const withIndex = (a: mixed, b: mixed, index: number): boolean => {
-        return index > 0 ? a === b : a !== b;
-      };
-      memoizeOne(fn, withIndex);
-
-      const withoutIndex = (a: mixed, b: mixed): boolean => a === b;
-      memoizeOne(fn, withoutIndex);
     });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -673,7 +673,13 @@ describe('memoizeOne', () => {
       const getMemoizedWithIndex = (fn: Function) => {
         let argIndex: number = 0;
         const withIndex = (newValue: mixed, oldValue: mixed) => customIsEqual(newValue, oldValue, argIndex++);
-        return memoizeOne(fn, withIndex);
+        const memoized = memoizeOne(fn, withIndex);
+
+        // every time this function is called it will reset our argIndex
+        return (...args: mixed[]) => {
+          argIndex = 0;
+          return memoized(...args);
+        };
       };
 
       const memoized = getMemoizedWithIndex(mock);
@@ -707,8 +713,10 @@ describe('memoizeOne', () => {
         const withIndex = (newValue: mixed, oldValue: mixed) => customIsEqual(newValue, oldValue, argIndex++, args);
         const memoized = memoizeOne(fn, withIndex);
 
+        // every time this function is called it will reset our args and argIndex
         return (...newArgs: mixed[]) => {
           args = newArgs;
+          argIndex = 0;
           return memoized(...newArgs);
         };
       };


### PR DESCRIPTION
Closes #39
Closes #47 
Rolls back #42

Rather than adding more arguments to our custom equality function: we provide examples on how to create higher order functions for passing in extra details to equality functions.

```diff
// recently added index in 4.1
- (a: mixed, b: mixed, index: number) => boolean
// removing it for compatibility reasons
+ (a: mixed, b: mixed) => boolean
```

This will be a breaking change as it will rollback the `index` argument