### PR TITLE
Give meaningful names to decorated functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const simpleIsEqual: EqualityFn = (
 // ResultFn:        Generic type (which is the same as the resultFn).
 // (...any[]): Accepts any length of arguments - and they are not checked
 // mixed:           The result can be anything but needs to be checked before usage
-export default function<ResultFn: (...any[]) => mixed>(
+export default function memoizeOne<ResultFn: (...any[]) => mixed>(
   resultFn: ResultFn,
   isEqual?: EqualityFn = simpleIsEqual,
 ): ResultFn {
@@ -30,7 +30,7 @@ export default function<ResultFn: (...any[]) => mixed>(
   let calledOnce: boolean = false;
 
   // breaking cache when context (this) or arguments change
-  const result = function(...newArgs: mixed[]) {
+  const memoized = function(...newArgs: mixed[]) {
     if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs)) {
       return lastResult;
     }
@@ -45,5 +45,12 @@ export default function<ResultFn: (...any[]) => mixed>(
     return lastResult;
   };
 
-  return (result: any);
+  // only reference the original name if it's present and not the empty string
+  if (resultFn.displayName) {
+    memoized.displayName = `memoized(${resultFn.displayName})`;
+  } else if (resultFn.name) {
+    memoized.displayName = `memoized(${resultFn.name})`;
+  }
+
+  return (memoized: any);
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -11,6 +11,27 @@ describe('memoizeOne', () => {
     return this.a;
   }
 
+  describe('name of the decorated function', () => {
+    it('should be named "memoize" with an undefined displayName if the input function is anonymous', () => {
+      expect(memoizeOne(() => {}).name).toBe('memoized');
+      expect(memoizeOne(() => {}).displayName).toBe(undefined);
+    });
+
+    it('should be named "memoize" with a displayName that reflects the input fn if the input function has a name but no displayName', () => {
+      function namedFn() {}
+      expect(memoizeOne(namedFn).name).toBe('memoized');
+      expect(memoizeOne(namedFn).displayName).toBe('memoized(namedFn)');
+    });
+
+    it('should be named "memoize" with a displayName that reflects the input fn if the input function has a displayName', () => {
+      function namedFn() {}
+      namedFn.displayName = 'someOtherName';
+
+      expect(memoizeOne(namedFn).name).toBe('memoized');
+      expect(memoizeOne(namedFn).displayName).toBe('memoized(someOtherName)');
+    });
+  });
+
   describe('standard behaviour - baseline', () => {
     let add;
     let memoizedAdd;


### PR DESCRIPTION
This:
* Names decorated functions simply "memoized" in the case the input function is anonymous
* Names decorated functions "memoized(foo)" in the case the input function has a `name` of "foo"
* Names decorated functions "memoized(foo)" in the case the input function has a `displayName` of "foo", despite having a `name` of "bar".

It also gives a name to the default export of `memoize-one` of "memoizeOne", as it was previously "index" in every case but the minified version, where it was the empty string and will continue to be.

Upside: Makes for debugging these decorated functions much easier in debugging tools and stack traces.

Downside: more checks and more names add to the size of the compiled output.

Test Plan: `yarn test`. Import the `main` entry from a repl and confirm the export is named `memoizeOne`.