### PR TITLE
Split function generic into generic types for args and return value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,36 +14,36 @@ const simpleIsEqual: EqualityFn = (
       shallowEqual(newArg, lastArgs[index]),
   );
 
-// <ResultFn: (...any[]) => mixed>
-// The purpose of this typing is to ensure that the returned memoized
-// function has the same type as the provided function (`resultFn`).
-// ResultFn:        Generic type (which is the same as the resultFn).
-// (...any[]): Accepts any length of arguments - and they are not checked
-// mixed:           The result can be anything but needs to be checked before usage
-export default function<ResultFn: (...any[]) => mixed>(
-  resultFn: ResultFn,
+// Type TArgs (arguments type) and TRet (return type) as generics to ensure that the
+// returned function (`memoized`) has the same type as the provided function (`inputFn`).
+//
+// `mixed` means that the result can be anything but needs to be checked before usage.
+// As opposed to `any`, it does not compromise type-safety.
+// See https://flow.org/en/docs/types/mixed/ for more.
+export default function memoizeOne<TArgs: mixed[], TRet: mixed>(
+  inputFn: (...TArgs) => TRet,
   isEqual?: EqualityFn = simpleIsEqual,
-): ResultFn {
+): (...TArgs) => TRet {
   let lastThis: mixed;
-  let lastArgs: mixed[] = [];
-  let lastResult: mixed;
+  let lastArgs: ?TArgs;
+  let lastResult: TRet; // not ?TRet because TRet must include undefined | null
   let calledOnce: boolean = false;
 
   // breaking cache when context (this) or arguments change
-  const result = function(...newArgs: mixed[]) {
-    if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs)) {
+  const memoized = function(...newArgs: TArgs): TRet {
+    if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs || [])) {
       return lastResult;
     }
 
     // Throwing during an assignment aborts the assignment: https://codepen.io/alexreardon/pen/RYKoaz
     // Doing the lastResult assignment first so that if it throws
     // nothing will be overwritten
-    lastResult = resultFn.apply(this, newArgs);
+    lastResult = inputFn.apply(this, newArgs);
     calledOnce = true;
     lastThis = this;
     lastArgs = newArgs;
     return lastResult;
   };
 
-  return (result: any);
+  return memoized;
 }


### PR DESCRIPTION
This allows us to specifically reference these types within `memoizeOne` and is more consistent with how decorators like these are typed elsewhere [1] [2]

This also has the nice side effect of removing the `any` casting on the memoized function.

This is a breaking change in the case users of `memoizeOne` were specifying `ResultType` specifically rather than letting Flow infer the type of it.

It also renames the input function to `inputFn` instead of `resultFn`, which I found confusing (I assume this stemmed from the name of the type that served to type both the input and output function). Hope that's all right.

I'm very open to feedback!

Test Plan: `yarn test`

[1] https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js#L789
[2] https://github.com/sindresorhus/mem/blob/master/index.d.ts#L74