### PR TITLE
Adding reset() for remove cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,35 @@ console.log(value1 === value3);
 // console.log => true
 ```
 
+## Reset cache
+
+Sometimes you might need to reset the memoization cache so it will force computation on the next call.
+It can be useful in some cases:
+
+- for testing if the memoized function is depended on external constants
+- the memoization used for calling function only when arguments change
+- freeing memory
+
+It can be done by calling `reset()`.
+
+```js
+const submitForm = email => {
+  /* some code */
+};
+
+const memoized = memoizeOne(submitForm);
+
+// All three will be called once
+memoized('unicorns@example.com');
+memoized('unicorns@example.com');
+memoized('unicorns@example.com');
+
+// Some time later, if we want to force calling `submitForm` again
+memoized.reset();
+// Next line will be call again, even if it got the same param of last time
+memoized('unicorns@example.com');
+```
+
 ## Performance :rocket:
 
 ### Tiny

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export type EqualityFn = (newArgs: mixed[], lastArgs: mixed[]) => boolean;
 export default function memoizeOne<ResultFn: (...any[]) => mixed>(
   resultFn: ResultFn,
   isEqual?: EqualityFn = areInputsEqual,
-): ResultFn {
+): ResultFn & { reset: () => void } {
   let lastThis: mixed;
   let lastArgs: mixed[] = [];
   let lastResult: mixed;
@@ -33,6 +33,21 @@ export default function memoizeOne<ResultFn: (...any[]) => mixed>(
     lastArgs = newArgs;
     return lastResult;
   };
+
+  // We allow to reset cache, in cases we need computations to re-happen. It can happen in 2 cases:
+  // - In cases `memoizeOne` not used for "result", but for side-effects that should
+  //   happens only when some of the "params" change
+  // - When for some reason, `resultFn` needs "impure" elements that will change
+  const reset = function() {
+    // Reset memoization
+    calledOnce = false;
+    // Clean cache from memory
+    lastThis = undefined;
+    lastArgs = [];
+    lastResult = undefined;
+  };
+
+  result.reset = reset;
 
   return (result: any);
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -725,4 +725,22 @@ describe('memoizeOne', () => {
       expect(result2).toBe(1);
     });
   });
+
+  describe('reset()', () => {
+    it('should reset cache and for calling resultFn for same values', () => {
+      const mock = jest.fn<[number], void>();
+      const memoized = memoizeOne<(_: number) => void>(mock);
+
+      memoized(1);
+      expect(mock).toBeCalledTimes(1);
+      memoized(1);
+      expect(mock).toBeCalledTimes(1);
+
+      memoized.reset();
+      memoized(1);
+      expect(mock).toBeCalledTimes(2);
+      memoized(1);
+      expect(mock).toBeCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
In one of the projects I work on, with quite similar utility to `memoizeOne` which have some differences. But, the only key difference the doesn't allow us to use `memoizeOne`, is the fact we can remove the cache.
I know it might be out of the scope of this project. So I understand it would be the reason to reject the PR. But, personally I find it a useful utility.