### PR TITLE
Convert to named export and add native esm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "memoize-one",
   "version": "5.1.1",
   "description": "A memoization library which only remembers the latest invocation",
-  "main": "dist/memoize-one.cjs.js",
+  "main": "dist/memoize-one.js",
   "types": "dist/memoize-one.d.ts",
-  "module": "dist/memoize-one.esm.js",
+  "module": "dist/esm/memoize-one.js",
+  "exports": {
+    ".": {
+      "require": "./dist/memoize-one.js",
+      "import": "./dist/esm/memoize-one.js"
+    }
+  },
   "sideEffects": false,
   "author": "Alex Reardon <alexreardon@gmail.com>",
   "license": "MIT",
@@ -18,20 +24,12 @@
   ],
   "size-limit": [
     {
-      "path": "dist/memoize-one.min.js",
-      "limit": "155B"
-    },
-    {
       "path": "dist/memoize-one.js",
-      "limit": "155B"
+      "limit": "165B"
     },
     {
-      "path": "dist/memoize-one.cjs.js",
-      "limit": "147B"
-    },
-    {
-      "path": "dist/memoize-one.esm.js",
-      "limit": "151B"
+      "path": "dist/esm/memoize-one.js",
+      "limit": "169B"
     }
   ],
   "keywords": [
@@ -58,8 +56,6 @@
     "prettier": "1.18.2",
     "rimraf": "3.0.0",
     "rollup": "^1.19.4",
-    "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-typescript": "^1.0.1",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
@@ -81,7 +77,7 @@
     "build:clean": "rimraf dist",
     "build:dist": "rollup -c",
     "build:typescript": "tsc ./src/memoize-one.ts --emitDeclarationOnly --declaration --outDir ./dist",
-    "build:flow": "cp src/memoize-one.js.flow dist/memoize-one.cjs.js.flow",
+    "build:flow": "cp src/memoize-one.js.flow dist/memoize-one.js.flow",
     "perf": "ts-node ./benchmarks/shallow-equal.ts",
     "prepublishOnly": "yarn build",
     "size": "yarn build && size-limit"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,16 @@
 // @ts-check
 import typescript from 'rollup-plugin-typescript';
-import replace from 'rollup-plugin-replace';
-import { terser } from 'rollup-plugin-terser';
 
 const input = 'src/memoize-one.ts';
+
+function emitModulePackageFile() {
+  return {
+    name: 'emit-module-package-file',
+    generateBundle() {
+      this.emitFile({ type: 'asset', fileName: 'package.json', source: `{"type":"module"}` });
+    },
+  };
+}
 
 export default [
   // Universal module definition (UMD) build
@@ -14,43 +21,15 @@ export default [
       format: 'umd',
       name: 'memoizeOne',
     },
-    plugins: [
-      // Setting development env before running other steps
-      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
-      typescript(),
-    ],
-  },
-  // Universal module definition (UMD) build (production)
-  {
-    input,
-    output: {
-      file: 'dist/memoize-one.min.js',
-      format: 'umd',
-      name: 'memoizeOne',
-    },
-    plugins: [
-      // Setting production env before running other steps
-      replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
-      typescript(),
-      terser(),
-    ],
+    plugins: [typescript()],
   },
   // ESM build
   {
     input,
     output: {
-      file: 'dist/memoize-one.esm.js',
+      file: 'dist/esm/memoize-one.js',
       format: 'esm',
     },
-    plugins: [typescript()],
-  },
-  // CommonJS build
-  {
-    input,
-    output: {
-      file: 'dist/memoize-one.cjs.js',
-      format: 'cjs',
-    },
-    plugins: [typescript()],
+    plugins: [typescript(), emitModulePackageFile()],
   },
 ];

--- a/src/memoize-one.js.flow
+++ b/src/memoize-one.js.flow
@@ -1,7 +1,7 @@
 // @flow
 export type EqualityFn = (newArgs: mixed[], lastArgs: mixed[]) => boolean;
 
-declare export default function memoizeOne<ResultFn: (...any[]) => mixed>(
+declare export function memoizeOne<ResultFn: (...any[]) => mixed>(
   fn: ResultFn,
   isEqual?: EqualityFn,
 ): ResultFn;

--- a/src/memoize-one.ts
+++ b/src/memoize-one.ts
@@ -3,7 +3,7 @@ import areInputsEqual from './are-inputs-equal';
 // Using ReadonlyArray<T> rather than readonly T as it works with TS v3
 export type EqualityFn = (newArgs: any[], lastArgs: any[]) => boolean;
 
-export default function memoizeOne<
+export function memoizeOne<
   // Need to use 'any' rather than 'unknown' here as it has
   // The correct Generic narrowing behaviour.
   ResultFn extends (this: any, ...newArgs: any[]) => ReturnType<ResultFn>

--- a/test/memoize-one.spec.ts
+++ b/test/memoize-one.spec.ts
@@ -1,4 +1,4 @@
-import memoize, { EqualityFn } from '../src/memoize-one';
+import { memoizeOne as memoize, EqualityFn } from '../src/memoize-one';
 import isDeepEqual from 'lodash.isequal';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,11 +2569,6 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-estree-walker@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
-  integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
-
 estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
@@ -4389,13 +4384,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-magic-string@^0.25.2:
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.2.tgz#139c3a729515ec55e96e69e82a11fe890a293ad9"
-  integrity sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==
-  dependencies:
-    sourcemap-codec "^1.4.4"
-
 make-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -6063,25 +6051,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-replace@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
-  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
-  dependencies:
-    magic-string "^0.25.2"
-    rollup-pluginutils "^2.6.0"
-
-rollup-plugin-terser@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.1.1.tgz#e9d2545ec8d467f96ba99b9216d2285aad8d5b66"
-  integrity sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    jest-worker "^24.6.0"
-    rollup-pluginutils "^2.8.1"
-    serialize-javascript "^1.7.0"
-    terser "^4.1.0"
-
 rollup-plugin-typescript@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.1.tgz#86565033b714c3d1f3aba510aad3dc519f7091e9"
@@ -6090,20 +6059,12 @@ rollup-plugin-typescript@^1.0.1:
     resolve "^1.10.0"
     rollup-pluginutils "^2.5.0"
 
-rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.8.1:
+rollup-pluginutils@^2.5.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
   integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
   dependencies:
     estree-walker "^0.6.1"
-
-rollup-pluginutils@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz#203706edd43dfafeaebc355d7351119402fc83ad"
-  integrity sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==
-  dependencies:
-    estree-walker "^0.6.0"
-    micromatch "^3.1.10"
 
 rollup@^1.19.4:
   version "1.19.4"
@@ -6249,11 +6210,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.8.0.tgz#9515fc687232e2321aea1ca7a529476eb34bb480"
-  integrity sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==
 
 serialize-javascript@^2.1.2:
   version "2.1.2"
@@ -6451,11 +6407,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-sourcemap-codec@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz#c63ea927c029dd6bd9a2b7fa03b3fec02ad56e9f"
-  integrity sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==
 
 spdx-correct@^3.0.0:
   version "3.0.0"
@@ -6795,15 +6746,6 @@ terser-webpack-plugin@^1.4.3:
     terser "^4.1.2"
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
-
-terser@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.2.0.tgz#4b1b5f4424b426a7a47e80d6aae45e0d7979aef0"
-  integrity sha512-6lPt7lZdZ/13icQJp8XasFOwZjFJkxFFIb/N1fhYEQNoNI3Ilo3KABZ9OocZvZoB39r6SiIk/0+v/bt8nZoSeA==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.12"
 
 terser@^4.1.2:
   version "4.6.3"


### PR DESCRIPTION
References
https://github.com/alexreardon/memoize-one/issues/37
https://github.com/rollup/rollup/blob/master/build-plugins/emit-module-package-file.js
https://unpkg.com/nanoevents@5.1.5/package.json

Node supports unflagged esm since v13. In this diff I changed default
import to memoizeOne named one.

```
import { memoizeOne } from 'memoize-one';
const { memoizeOne } = require('memoize-one');
const { memoizeOne } = window.memoizeOne;
```

The main reason is TS support without fighting with default commonjs/esm
interop which forces to import a function as a namespace.

```
import * as memoizeOne from 'memoize-one';
```

This is incorrect. Module namespace is an object due spec.

Libraries like nanoevents and nanoid ended with named export aswell.
See details here https://github.com/ai/nanoid/issues/128

Also I simplified generated bundles to one umd and one esm because project does not have dependencies and process.env.NODE_ENV usages.