### PR TITLE
Improve type inference

### DIFF
--- a/src/memoize-one.ts
+++ b/src/memoize-one.ts
@@ -1,20 +1,25 @@
 import areInputsEqual from './are-inputs-equal';
 
 // Using ReadonlyArray<T> rather than readonly T as it works with TS v3
-export type EqualityFn = (newArgs: any[], lastArgs: any[]) => boolean;
+export type EqualityFn<Args extends any[] = any[]> = (newArgs: Args, lastArgs: Args) => boolean;
 
 export default function memoizeOne<
+  This,
   // Need to use 'any' rather than 'unknown' here as it has
   // The correct Generic narrowing behaviour.
-  ResultFn extends (this: any, ...newArgs: any[]) => ReturnType<ResultFn>
->(resultFn: ResultFn, isEqual: EqualityFn = areInputsEqual): ResultFn {
-  let lastThis: unknown;
-  let lastArgs: unknown[] = [];
-  let lastResult: ReturnType<ResultFn>;
+  Args extends any[],
+  R
+>(
+  resultFn: (this: This, ...newArgs: Args) => R,
+  isEqual: EqualityFn<Args> = areInputsEqual,
+): (this: This, ...newArgs: Args) => R {
+  let lastThis: This;
+  let lastArgs: any = [];
+  let lastResult: R;
   let calledOnce: boolean = false;
 
   // breaking cache when context (this) or arguments change
-  function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<ResultFn> {
+  function memoized(this: This, ...newArgs: Args): R {
     if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs)) {
       return lastResult;
     }
@@ -29,5 +34,5 @@ export default function memoizeOne<
     return lastResult;
   }
 
-  return memoized as ResultFn;
+  return memoized;
 }

--- a/test/memoize-one.spec.ts
+++ b/test/memoize-one.spec.ts
@@ -728,14 +728,13 @@ describe('typing', () => {
   it('should support typed equality functions', () => {
     const subtract = (a: number, b: number): number => a - b;
 
-    const valid: EqualityFn[] = [
-      (newArgs: readonly number[], lastArgs: readonly number[]): boolean =>
-        JSON.stringify(newArgs) === JSON.stringify(lastArgs),
+    const valid: EqualityFn<[number, number]>[] = [
+      (newArgs, lastArgs): boolean => JSON.stringify(newArgs) === JSON.stringify(lastArgs),
       (): boolean => true,
-      (value: unknown[]): boolean => value.length === 5,
+      (value): boolean => value.length === 2,
     ];
 
-    valid.forEach((isEqual: EqualityFn) => {
+    valid.forEach((isEqual: EqualityFn<[number, number]>) => {
       const memoized = memoize(subtract, isEqual);
       expect(memoized(3, 1)).toBe(2);
     });


### PR DESCRIPTION
So that memoizeOne can infer the type of the isEqual function parameter by itself

For example:

```typescript
export const doSomething = memoizeOne(
  (a: string, b: number) { ... },

  // newA, newB, oldA, oldB type will be infered automatically
  ([newA, newB], [oldA, oldB]) => ...,
)
```