### PR TITLE
Make memoize-one.cjs.js work with ts

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,6 +50,7 @@ export default [
     output: {
       file: 'dist/memoize-one.cjs.js',
       format: 'cjs',
+      outro: 'memoizeOne.default = memoizeOne;',
     },
     plugins: [typescript()],
   },


### PR DESCRIPTION
Currently the following code under nodejs

```js
import * as memoizeOne from 'memoize-one'
```

Will be prompted that `memoizeOne` has no call signatures, but the
following code will cause the nodejs program to report an error (because
memoize-one.cjs.js does not set `module.exports.default`)

```js
import memoizeOne from 'memoize-one'
```

So I added the `default` property to `memoizeOne` (`module.exports`)
of memoize-one.cjs.js