### PR TITLE
Fix misleading readme for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Unlike other memoization libraries, `memoize-one` only remembers the latest argu
 ## Usage
 
 ```js
-import { memoizeOne } from 'memoize-one';
+import memoizeOne from 'memoize-one';
 
 const add = (a, b) => a + b;
 const memoizedAdd = memoizeOne(add);
@@ -38,15 +38,6 @@ memoizedAdd(1, 2); // 3
 // Add function is called to get new value.
 // While this was previously cached,
 // it is not the latest so the cached result is lost
-```
-
-You can use the default export or a named import
-
-```js
-// Named import
-import { memoizeOne } from 'memoize-one';
-// Default import
-import memoizeOne from 'memoize-one';
 ```
 
 ## Installation


### PR DESCRIPTION
There is no named export, only default export.