### PR TITLE
removing named import

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Unlike other memoization libraries, `memoize-one` only remembers the latest argu
 ## Usage
 
 ```js
+// memoize-one uses the default import
 import memoizeOne from 'memoize-one';
 
 const add = (a, b) => a + b;
@@ -38,12 +39,6 @@ memoizedAdd(1, 2); // 3
 // Add function is called to get new value.
 // While this was previously cached,
 // it is not the latest so the cached result is lost
-```
-
-You can use the default import of `'memoize-one'`
-
-```js
-import memoizeOne from 'memoize-one';
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Unlike other memoization libraries, `memoize-one` only remembers the latest argu
 ## Usage
 
 ```js
-import { memoizeOne } from 'memoize-one';
+import memoizeOne from 'memoize-one';
 
 const add = (a, b) => a + b;
 const memoizedAdd = memoizeOne(add);
@@ -40,12 +40,9 @@ memoizedAdd(1, 2); // 3
 // it is not the latest so the cached result is lost
 ```
 
-You can use the default import or a named import
+You can use the default import of `'memoize-one'`
 
 ```js
-// Named import
-import { memoizeOne } from 'memoize-one';
-// Default import
 import memoizeOne from 'memoize-one';
 ```
 
@@ -72,7 +69,7 @@ By default, we apply our own _fast_ and _naive_ equality function to determine w
 What this looks like in practice:
 
 ```js
-import { memoizeOne } from 'memoize-one';
+import memoizeOne from 'memoize-one';
 
 // add all numbers provided to the function
 const add = (...args = []) =>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,6 +50,7 @@ export default [
     output: {
       file: 'dist/memoize-one.cjs.js',
       format: 'cjs',
+      exports: 'default',
     },
     plugins: [typescript()],
   },

--- a/src/memoize-one.js.flow
+++ b/src/memoize-one.js.flow
@@ -6,9 +6,3 @@ declare export default function memoizeOne<ResultFn: (...any[]) => mixed>(
   fn: ResultFn,
   isEqual?: EqualityFn,
 ): ResultFn;
-
-// named export
-declare export function memoizeOne<ResultFn: (...any[]) => mixed>(
-  fn: ResultFn,
-  isEqual?: EqualityFn,
-): ResultFn;

--- a/src/memoize-one.ts
+++ b/src/memoize-one.ts
@@ -34,7 +34,7 @@ function memoizeOne<
 
 // default export
 export default memoizeOne;
-// named export
+
 // disabled for now as mixing named and
 // default exports is problematic with CommonJS
 // export { memoizeOne };

--- a/src/memoize-one.ts
+++ b/src/memoize-one.ts
@@ -35,4 +35,6 @@ function memoizeOne<
 // default export
 export default memoizeOne;
 // named export
-export { memoizeOne };
+// disabled for now as mixing named and
+// default exports is problematic with CommonJS
+// export { memoizeOne };

--- a/test/memoize-one.spec.ts
+++ b/test/memoize-one.spec.ts
@@ -1,4 +1,4 @@
-import { memoizeOne as memoize, EqualityFn } from '../src/memoize-one';
+import memoize, { EqualityFn } from '../src/memoize-one';
 import isDeepEqual from 'lodash.isequal';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 


### PR DESCRIPTION
Fixes #116. Will undo the problematic addition of named imports.

Plan

- merge this change
- release 5.2.1
- deprecate 5.2.0