### PR TITLE
post ie11 memoize-one

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-jest": "^24.3.5",
     "eslint-plugin-prettier": "^3.3.1",
+    "expect-type": "^0.12.0",
     "jest": "^26.6.3",
     "lodash.isequal": "^4.5.0",
     "prettier": "2.2.1",

--- a/src/next.ts
+++ b/src/next.ts
@@ -46,7 +46,14 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   }
 
   // Giving the function a better name for devtools
-  Object.defineProperty(memoized, 'name', { value: `memoized(${resultFn.name})`, writable: true });
+  Object.defineProperty(memoized, 'name', {
+    value: `memoized(${resultFn.name})`,
+    // fn.name is configurable, so maintaining that.
+    configurable: true,
+    // Using the default values:
+    // enumerable: false,
+    // writable: false,
+  });
 
   // Adding the ability to clear the cache of a memoized function
   memoized.clear = function clear() {

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,27 +1,30 @@
 import areInputsEqual from './are-inputs-equal';
 
 // Using ReadonlyArray<T> rather than readonly T as it works with TS v3
-export type EqualityFn = (newArgs: any[], lastArgs: any[]) => boolean;
+export type EqualityFn<TFunc extends (...args: any[]) => any> = (
+  newArgs: Parameters<TFunc>,
+  lastArgs: Parameters<TFunc>,
+) => boolean;
 
-type Cache<TResult> = {
+type Cache<TResult, TArgs> = {
   lastThis: unknown;
-  lastArgs: unknown[];
+  lastArgs: TArgs;
   lastResult: TResult;
 };
 
-type MemoizedFn<T extends (this: any, ...args: any[]) => any> = {
+type MemoizedFn<TFunc extends (this: any, ...args: any[]) => any> = {
   clear: () => void;
-  (...args: Parameters<T>): ReturnType<T>;
+  (...args: Parameters<TFunc>): ReturnType<TFunc>;
 };
 
 function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   resultFn: TFunc,
-  isEqual: EqualityFn = areInputsEqual,
+  isEqual: EqualityFn<TFunc> = areInputsEqual,
 ): MemoizedFn<TFunc> {
-  let cache: Cache<ReturnType<TFunc>> | null = null;
+  let cache: Cache<ReturnType<TFunc>, Parameters<TFunc>> | null = null;
 
   // breaking cache when context (this) or arguments change
-  function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<TFunc> {
+  function memoized(this: unknown, ...newArgs: Parameters<TFunc>): ReturnType<TFunc> {
     if (cache && cache.lastThis === this && isEqual(newArgs, cache.lastArgs)) {
       return cache.lastResult;
     }

--- a/src/next.ts
+++ b/src/next.ts
@@ -19,12 +19,11 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   resultFn: TFunc,
   isEqual: EqualityFn = areInputsEqual,
 ): MemoizedFn<TFunc> {
-  let map = new WeakMap<Record<string, any>, Cache<ReturnType<TFunc>>>();
-  let key = {};
+  const map = new Map<'cache', Cache<ReturnType<TFunc>>>();
 
   // breaking cache when context (this) or arguments change
   function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<TFunc> {
-    const cache = map.get(key);
+    const cache = map.get('cache');
     if (cache) {
       // Okay, we have something in the cache.
       // is this cache still valid?
@@ -37,7 +36,7 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
     // Or our parameters have changed.
 
     const lastResult = resultFn.apply(this, newArgs);
-    map.set(key, {
+    map.set('cache', {
       lastResult,
       lastArgs: newArgs,
       lastThis: this,
@@ -51,10 +50,7 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
 
   // Adding the ability to clear the cache of a memoized function
   memoized.clear = function clear() {
-    // standard way to clear a weakmap is to create another one
-    // as there is no 'clear' method for security reasons
-    key = {};
-    map = new WeakMap<Cache<ReturnType<TFunc>>>();
+    map.delete('cache');
   };
 
   return memoized;

--- a/src/next.ts
+++ b/src/next.ts
@@ -10,7 +10,6 @@ type Cache<TResult> = {
 };
 
 type MemoizedFn<T extends (this: any, ...args: any[]) => any> = {
-  name: string;
   clear: () => void;
   (...args: Parameters<T>): ReturnType<T>;
 };

--- a/src/next.ts
+++ b/src/next.ts
@@ -6,10 +6,10 @@ export type EqualityFn<TFunc extends (...args: any[]) => any> = (
   lastArgs: Parameters<TFunc>,
 ) => boolean;
 
-type Cache<TThis, TArgs, TResult> = {
-  lastThis: TThis;
-  lastArgs: TArgs;
-  lastResult: TResult;
+type Cache<TFunc extends (this: any, ...args: any[]) => any> = {
+  lastThis: ThisParameterType<TFunc>;
+  lastArgs: Parameters<TFunc>;
+  lastResult: ReturnType<TFunc>;
 };
 
 type MemoizedFn<TFunc extends (this: any, ...args: any[]) => any> = {
@@ -21,7 +21,7 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   resultFn: TFunc,
   isEqual: EqualityFn<TFunc> = areInputsEqual,
 ): MemoizedFn<TFunc> {
-  let cache: Cache<ThisParameterType<TFunc>, Parameters<TFunc>, ReturnType<TFunc>> | null = null;
+  let cache: Cache<TFunc> | null = null;
 
   // breaking cache when context (this) or arguments change
   function memoized(

--- a/src/next.ts
+++ b/src/next.ts
@@ -24,17 +24,13 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   // breaking cache when context (this) or arguments change
   function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<TFunc> {
     const cache = map.get('cache');
-    if (cache) {
-      // Okay, we have something in the cache.
-      // is this cache still valid?
-      if (cache.lastThis === this && isEqual(newArgs, cache.lastArgs)) {
-        return cache.lastResult;
-      }
+    if (cache && cache.lastThis === this && isEqual(newArgs, cache.lastArgs)) {
+      return cache.lastResult;
     }
 
-    // At this point, either we have nothing in the cache;
-    // Or our parameters have changed.
-
+    // Throwing during an assignment aborts the assignment: https://codepen.io/alexreardon/pen/RYKoaz
+    // Doing the lastResult assignment first so that if it throws
+    // nothing will be overwritten
     const lastResult = resultFn.apply(this, newArgs);
     map.set('cache', {
       lastResult,

--- a/src/next.ts
+++ b/src/next.ts
@@ -14,7 +14,7 @@ type Cache<TThis, TArgs, TResult> = {
 
 type MemoizedFn<TFunc extends (this: any, ...args: any[]) => any> = {
   clear: () => void;
-  (...args: Parameters<TFunc>): ReturnType<TFunc>;
+  (this: ThisParameterType<TFunc>, ...args: Parameters<TFunc>): ReturnType<TFunc>;
 };
 
 function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
@@ -63,5 +63,4 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   return memoized;
 }
 
-// default export
-export default memoizeOne;
+export { memoizeOne };

--- a/src/next.ts
+++ b/src/next.ts
@@ -46,7 +46,7 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   }
 
   // Giving the function a better name for devtools
-  Object.defineProperty(memoized, 'name', { value: `memoized(${resultFn.name})`, writable: false });
+  Object.defineProperty(memoized, 'name', { value: `memoized(${resultFn.name})`, writable: true });
 
   // Adding the ability to clear the cache of a memoized function
   memoized.clear = function clear() {

--- a/src/next.ts
+++ b/src/next.ts
@@ -3,14 +3,14 @@ import areInputsEqual from './are-inputs-equal';
 // Using ReadonlyArray<T> rather than readonly T as it works with TS v3
 export type EqualityFn = (newArgs: any[], lastArgs: any[]) => boolean;
 
-type State = {
+type State<TResult> = {
   lastThis: unknown;
   lastArgs: unknown[];
-  lastResult: unknown;
+  lastResult: TResult | undefined;
   calledOnce: boolean;
 };
 
-function getInitialState(): State {
+function getInitialState<TResult>(): State<TResult> {
   return {
     lastThis: undefined,
     lastArgs: [],
@@ -19,18 +19,24 @@ function getInitialState(): State {
   };
 }
 
+type MemoizedFn<T extends (this: any, ...args: any[]) => any> = {
+  name: string;
+  clear: () => void;
+  (...args: Parameters<T>): ReturnType<T>;
+};
+
 function memoizeOne<
   // Need to use 'any' rather than 'unknown' here as it has
   // The correct Generic narrowing behaviour.
-  ResultFn extends (this: any, ...newArgs: any[]) => ReturnType<ResultFn>
->(resultFn: ResultFn, isEqual: EqualityFn = areInputsEqual): ResultFn {
-  let state: State = getInitialState();
+  TFunc extends (this: any, ...newArgs: any[]) => any
+>(resultFn: TFunc, isEqual: EqualityFn = areInputsEqual): MemoizedFn<TFunc> {
+  let state: State<ReturnType<TFunc>> = getInitialState();
 
   // breaking cache when context (this) or arguments change
-  function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<ResultFn> {
+  function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<TFunc> {
     const { lastThis, lastArgs, lastResult, calledOnce } = state;
     if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs)) {
-      return lastResult;
+      return lastResult as ReturnType<TFunc>;
     }
 
     // Throwing during an assignment aborts the assignment: https://codepen.io/alexreardon/pen/RYKoaz
@@ -43,9 +49,13 @@ function memoizeOne<
       lastArgs: newArgs,
     };
 
-    return state.lastResult;
+    return state.lastResult as ReturnType<TFunc>;
   }
 
+  // Giving the function a better name for devtools
+  memoized.name = `memoized(${resultFn.name})`;
+
+  // Adding the ability to clear the cache of a memoized function
   memoized.clear = function clear() {
     state = getInitialState();
   };

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,0 +1,57 @@
+import areInputsEqual from './are-inputs-equal';
+
+// Using ReadonlyArray<T> rather than readonly T as it works with TS v3
+export type EqualityFn = (newArgs: any[], lastArgs: any[]) => boolean;
+
+type State = {
+  lastThis: unknown;
+  lastArgs: unknown[];
+  lastResult: unknown;
+  calledOnce: boolean;
+};
+
+function getInitialState(): State {
+  return {
+    lastThis: undefined,
+    lastArgs: [],
+    lastResult: undefined,
+    calledOnce: false,
+  };
+}
+
+function memoizeOne<
+  // Need to use 'any' rather than 'unknown' here as it has
+  // The correct Generic narrowing behaviour.
+  ResultFn extends (this: any, ...newArgs: any[]) => ReturnType<ResultFn>
+>(resultFn: ResultFn, isEqual: EqualityFn = areInputsEqual): ResultFn {
+  let state: State = getInitialState();
+
+  // breaking cache when context (this) or arguments change
+  function memoized(this: unknown, ...newArgs: unknown[]): ReturnType<ResultFn> {
+    const { lastThis, lastArgs, lastResult, calledOnce } = state;
+    if (calledOnce && lastThis === this && isEqual(newArgs, lastArgs)) {
+      return lastResult;
+    }
+
+    // Throwing during an assignment aborts the assignment: https://codepen.io/alexreardon/pen/RYKoaz
+    // Doing the lastResult assignment first so that if it throws
+    // nothing will be overwritten
+    state = {
+      lastResult: resultFn.apply(this, newArgs),
+      calledOnce: true,
+      lastThis: this,
+      lastArgs: newArgs,
+    };
+
+    return state.lastResult;
+  }
+
+  memoized.clear = function clear() {
+    state = getInitialState();
+  };
+
+  return memoized;
+}
+
+// default export
+export default memoizeOne;

--- a/src/next.ts
+++ b/src/next.ts
@@ -43,7 +43,7 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
 
   // Giving the function a better name for devtools
   Object.defineProperty(memoized, 'name', {
-    value: `memoized(${resultFn.name})`,
+    value: `memoized(${resultFn.name || 'anonymous'})`,
     // fn.name is configurable, so maintaining that.
     configurable: true,
     // Using the default values:

--- a/src/next.ts
+++ b/src/next.ts
@@ -34,7 +34,7 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
 
     // Throwing during an assignment aborts the assignment: https://codepen.io/alexreardon/pen/RYKoaz
     // Doing the lastResult assignment first so that if it throws
-    // nothing will be overwritten
+    // the cache will be overwritten
     const lastResult = resultFn.apply(this, newArgs);
     cache = {
       lastResult,

--- a/src/next.ts
+++ b/src/next.ts
@@ -6,8 +6,8 @@ export type EqualityFn<TFunc extends (...args: any[]) => any> = (
   lastArgs: Parameters<TFunc>,
 ) => boolean;
 
-type Cache<TResult, TArgs> = {
-  lastThis: unknown;
+type Cache<TThis, TArgs, TResult> = {
+  lastThis: TThis;
   lastArgs: TArgs;
   lastResult: TResult;
 };
@@ -21,10 +21,13 @@ function memoizeOne<TFunc extends (this: any, ...newArgs: any[]) => any>(
   resultFn: TFunc,
   isEqual: EqualityFn<TFunc> = areInputsEqual,
 ): MemoizedFn<TFunc> {
-  let cache: Cache<ReturnType<TFunc>, Parameters<TFunc>> | null = null;
+  let cache: Cache<ThisParameterType<TFunc>, Parameters<TFunc>, ReturnType<TFunc>> | null = null;
 
   // breaking cache when context (this) or arguments change
-  function memoized(this: unknown, ...newArgs: Parameters<TFunc>): ReturnType<TFunc> {
+  function memoized(
+    this: ThisParameterType<TFunc>,
+    ...newArgs: Parameters<TFunc>
+  ): ReturnType<TFunc> {
     if (cache && cache.lastThis === this && isEqual(newArgs, cache.lastArgs)) {
       return cache.lastResult;
     }

--- a/test/memoize-one-next.spec.ts
+++ b/test/memoize-one-next.spec.ts
@@ -1,7 +1,5 @@
 // TODO: import and test both
-import memoize, { EqualityFn } from '../src/next';
-import isDeepEqual from 'lodash.isequal';
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { memoizeOne as memoize } from '../src/next';
 
 it('should give the memoized function a helpful name (named fn)', () => {
   function add(...args: number[]) {

--- a/test/memoize-one-next.spec.ts
+++ b/test/memoize-one-next.spec.ts
@@ -1,0 +1,13 @@
+// TODO: import and test both
+import memoize, { EqualityFn } from '../src/next';
+import isDeepEqual from 'lodash.isequal';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+it('should give the memoized function a helpful name', () => {
+  function add(...args: number[]) {
+    return args.reduce((acc, current) => acc + current, 0);
+  }
+
+  const memoized = memoize(add);
+  expect(memoized.name).toBe('memoized(add)');
+});

--- a/test/memoize-one-next.spec.ts
+++ b/test/memoize-one-next.spec.ts
@@ -2,10 +2,9 @@
 import { memoizeOne as memoize } from '../src/next';
 
 it('should give the memoized function a helpful name (named fn)', () => {
-  function add(...args: number[]) {
-    return args.reduce((acc, current) => acc + current, 0);
+  function add(a: number, b: number) {
+    return a + b;
   }
-
   const memoized = memoize(add);
   expect(memoized.name).toBe('memoized(add)');
 });
@@ -13,4 +12,30 @@ it('should give the memoized function a helpful name (named fn)', () => {
 it('should give the memoized function a helpful name (anonymous fn)', () => {
   const memoized = memoize(() => 'hi');
   expect(memoized.name).toBe('memoized(anonymous)');
+});
+
+it('should enable cache clearing', () => {
+  const underlyingFn = jest.fn(function add(a: number, b: number) {
+    return a + b;
+  });
+
+  const memoizedAdd = memoize(underlyingFn);
+
+  // first call - not memoized
+  const first = memoizedAdd(1, 2);
+  expect(first).toBe(3);
+  expect(underlyingFn).toHaveBeenCalledTimes(1);
+
+  // second call - memoized (underlying function not called)
+  const second = memoizedAdd(1, 2);
+  expect(second).toBe(3);
+  expect(underlyingFn).toHaveBeenCalledTimes(1);
+
+  // clearing memoization cache
+  memoizedAdd.clear();
+
+  // third call - not memoized (cache was cleared)
+  const third = memoizedAdd(1, 2);
+  expect(third).toBe(3);
+  expect(underlyingFn).toHaveBeenCalledTimes(2);
 });

--- a/test/memoize-one-next.spec.ts
+++ b/test/memoize-one-next.spec.ts
@@ -3,11 +3,16 @@ import memoize, { EqualityFn } from '../src/next';
 import isDeepEqual from 'lodash.isequal';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-it('should give the memoized function a helpful name', () => {
+it('should give the memoized function a helpful name (named fn)', () => {
   function add(...args: number[]) {
     return args.reduce((acc, current) => acc + current, 0);
   }
 
   const memoized = memoize(add);
   expect(memoized.name).toBe('memoized(add)');
+});
+
+it('should give the memoized function a helpful name (anonymous fn)', () => {
+  const memoized = memoize(() => 'hi');
+  expect(memoized.name).toBe('memoized(anonymous)');
 });

--- a/test/memoize-one.spec.ts
+++ b/test/memoize-one.spec.ts
@@ -1,4 +1,5 @@
-import memoize, { EqualityFn } from '../src/memoize-one';
+// TODO: import and test both
+import memoize, { EqualityFn } from '../src/next';
 import isDeepEqual from 'lodash.isequal';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/test/memoize-one.spec.ts
+++ b/test/memoize-one.spec.ts
@@ -1,5 +1,5 @@
 // TODO: import and test both
-import memoize, { EqualityFn } from '../src/next';
+import { memoizeOne as memoize, EqualityFn } from '../src/next';
 import isDeepEqual from 'lodash.isequal';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/test/memoize-one.spec.ts
+++ b/test/memoize-one.spec.ts
@@ -496,7 +496,7 @@ describe('skip equality check', () => {
 describe('custom equality function', () => {
   let add: AddFn;
   let memoizedAdd: AddFn;
-  let equalityStub: EqualityFn;
+  let equalityStub: EqualityFn<AddFn>;
 
   beforeEach(() => {
     add = jest.fn().mockImplementation((value1: number, value2: number): number => value1 + value2);
@@ -751,14 +751,14 @@ describe('typing', () => {
   it('should support typed equality functions', () => {
     const subtract = (a: number, b: number): number => a - b;
 
-    const valid: EqualityFn[] = [
+    const valid = [
       (newArgs: readonly number[], lastArgs: readonly number[]): boolean =>
         JSON.stringify(newArgs) === JSON.stringify(lastArgs),
       (): boolean => true,
       (value: unknown[]): boolean => value.length === 5,
     ];
 
-    valid.forEach((isEqual: EqualityFn) => {
+    valid.forEach((isEqual) => {
       const memoized = memoize(subtract, isEqual);
       expect(memoized(3, 1)).toBe(2);
     });

--- a/test/types-test.spec.ts
+++ b/test/types-test.spec.ts
@@ -1,0 +1,16 @@
+import { expectTypeOf } from 'expect-type';
+import { memoizeOne } from '../src/next';
+
+it('should maintain the types of the original function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function getLocation(this: Window, value: number) {
+    return this.location;
+  }
+  const memoized = memoizeOne(getLocation);
+
+  expectTypeOf<ThisParameterType<typeof getLocation>>().toEqualTypeOf<
+    ThisParameterType<typeof memoized>
+  >();
+  expectTypeOf<Parameters<typeof getLocation>>().toEqualTypeOf<Parameters<typeof memoized>>();
+  expectTypeOf<ReturnType<typeof getLocation>>().toEqualTypeOf<ReturnType<typeof memoized>>();
+});

--- a/test/types-test.spec.ts
+++ b/test/types-test.spec.ts
@@ -14,3 +14,16 @@ it('should maintain the types of the original function', () => {
   expectTypeOf<Parameters<typeof getLocation>>().toEqualTypeOf<Parameters<typeof memoized>>();
   expectTypeOf<ReturnType<typeof getLocation>>().toEqualTypeOf<ReturnType<typeof memoized>>();
 });
+
+it('should add a .clear function', () => {
+  function add(first: number, second: number) {
+    return first + second;
+  }
+  const memoized = memoizeOne(add);
+  memoized.clear();
+
+  // @ts-expect-error
+  expect(() => memoized.foo()).toThrow();
+
+  expectTypeOf<typeof memoized.clear>().toEqualTypeOf<() => void>();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,6 +2666,11 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expect-type@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.12.0.tgz#133534b5e2561158c371e74af63fd8f18a9f3d42"
+  integrity sha512-IHwziEOjpjXqxQhtOAD5zMiQpGztaEKM4Q8wnwoRN9NIFlnyNHNjRxKWv+18UqRfsqi6vVnZIYFU16ePf+HaqA==
+
 expect@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"


### PR DESCRIPTION
I am trying out some quality of life improvements to `memoize-one` for people who don't need to support ie11

This new version would likely be a seperate entry point. Something like `memoize-one/next` so as to not break anyone. Buuut maybe I just do a `major` (see open questions)

## Goals

- [ ] Give the memoized function a better `name` (eg `memoized(${originalFunction.name})` → `memoized(foo)`))
- [x] Add the ability to clear the cache of a memoized function `memoizedFn.clear()`
- [ ] Ensure that memoized functions can be garbage collected well. Idea: use a weakmap?
- [ ] Allow consumption of new version without impacting existing users (probably ESM only) (`memoize-one/next`). 
- [x] Improve the typing of the memoized function and any provided isEqual functions
- [x] move to named import only for `next`

This implementation is not compatible with ie11

## Open questions:

- Should `next` be a seperate entry point? Should I do a `major` and just move forward? IE11 consumers can continue to use the old version
- Should I be setting `fn.name` or `fn.displayName`. [Function.displayName is non-standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName)

## Providing a function name

A function always has a `.name` property. When the function is anonymous it has the empty string `''` as it's name.

To make things clearer in stack traces and dev tools, the thinking is to give memoized functions a clearer name.

### Named functions

`name` → `memoized(name)`

```ts
function add(...args: number[]) {
    return args.reduce((acc, current) => acc + current, 0);
  }

  const memoized = memoize(add);
  expect(memoized.name).toBe('memoized(add)');
```

### anonymous functions

> anonymous functions `.name` is empty string `''`

This is the option I like the most: `''` → `memoized(anonymous)`

```ts
const memoized = memoize(() => 'hi');
expect(memoized.name).toBe('memoized(anonymous)');
 ```

Some other options for naming memoized anonymous functions:

- `memoized`
- `''` (don't touch the name)

_That's all I can think of_